### PR TITLE
Use plugin config file & add max-width and max-height

### DIFF
--- a/datasette_render_image_tags/__init__.py
+++ b/datasette_render_image_tags/__init__.py
@@ -18,6 +18,7 @@ def render_cell(value, datasette):
         plugin_config = {}
     max_width = plugin_config.get("max_width", DEFAULT_MAX_WIDTH)
     max_height = plugin_config.get("max_height", DEFAULT_MAX_HEIGHT)
+    fixed_width = plugin_config.get("fixed_width", None)
 
     value = value.strip()
 
@@ -28,6 +29,9 @@ def render_cell(value, datasette):
         or all(not value.lower().endswith(ext) for ext in FILE_EXTENSIONS)
     ):
         return None
-
+    if fixed_width is not None:
+        return Markup(
+            f'<img src="{escape(value)}" width="{fixed_width}" loading="lazy">'
+        )
     style = f"display: block;margin: 0 auto;max-width: {max_width}px;max-height: {max_height}px;"
     return Markup(f'<img src="{escape(value)}" loading="lazy" style="{style}">')

--- a/datasette_render_image_tags/__init__.py
+++ b/datasette_render_image_tags/__init__.py
@@ -1,17 +1,33 @@
 from datasette import hookimpl
 from markupsafe import Markup, escape
 
-ENDS = (".jpg", ".jpeg", ".png", ".gif")
+FILE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".gif")
+DEFAULT_MAX_WIDTH, DEFAULT_MAX_HEIGHT = (200, 200)
 
 
 @hookimpl
-def render_cell(value):
+def render_cell(value, datasette):
     if not isinstance(value, str):
         return
+
+    if datasette and (
+        plugin_config := datasette.plugin_config("datasette-render-image-tags")
+    ):
+        pass
+    else:
+        plugin_config = {}
+    max_width = plugin_config.get("max_width", DEFAULT_MAX_WIDTH)
+    max_height = plugin_config.get("max_height", DEFAULT_MAX_HEIGHT)
+
     value = value.strip()
-    if not value or " " in value:
-        return
-    if not (value.startswith("http://") or value.startswith("https://")):
-        return
-    if any(value.lower().endswith(end) for end in ENDS):
-        return Markup('<img src="{}" width="200" loading="lazy">'.format(escape(value)))
+
+    if (
+        not value
+        or " " in value
+        or not (value.startswith("http://") or value.startswith("https://"))
+        or all(not value.lower().endswith(ext) for ext in FILE_EXTENSIONS)
+    ):
+        return None
+
+    style = f"display: block;margin: 0 auto;max-width: {max_width}px;max-height: {max_height}px;"
+    return Markup(f'<img src="{escape(value)}" loading="lazy" style="{style}">')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
-from setuptools import setup
 import os
 
-VERSION = "0.1"
+from setuptools import setup
+
+VERSION = "0.2"
 
 
 def get_long_description():
@@ -33,6 +34,6 @@ setup(
     packages=["datasette_render_image_tags"],
     entry_points={"datasette": ["render_image_tags = datasette_render_image_tags"]},
     install_requires=["datasette"],
-    extras_require={"test": ["pytest", "pytest-asyncio"]},
+    extras_require={"test": ["pytest", "pytest-asyncio", "sqlite-utils"]},
     python_requires=">=3.7",
 )

--- a/tests/test_render_image_tags.py
+++ b/tests/test_render_image_tags.py
@@ -1,12 +1,29 @@
-from datasette.app import Datasette
 from urllib.parse import urlencode
-from markupsafe import escape
+
 import pytest
+import sqlite_utils
+from datasette.app import Datasette
+
+
+@pytest.fixture(scope="function")
+def db_path(tmp_path_factory) -> sqlite_utils.Database:
+    db_directory = tmp_path_factory.mktemp("dbs")
+    db_path = db_directory / "test.db"
+    return db_path
+
+
+@pytest.mark.asyncio
+async def test_plugin_is_installed():
+    datasette = Datasette(memory=True)
+    response = await datasette.client.get("/-/plugins.json")
+    assert response.status_code == 200
+    installed_plugins = {p["name"] for p in response.json()}
+    assert "datasette-render-image-tags" in installed_plugins
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "value,expect_img",
+    "url,expect_img",
     (
         (1, False),
         (1.2, False),
@@ -21,23 +38,59 @@ import pytest
         ("https://blah/has_url.mp3", False),
     ),
 )
-async def test_mp3_audio(value, expect_img):
-    datasette = Datasette(memory=True)
-    response = await datasette.client.get(
-        "/_memory?"
-        + urlencode(
-            {
-                "sql": "select :value as value",
-                "value": value,
-            }
-        )
+async def test_img_is_rendered(db_path, url, expect_img):
+    datasette = Datasette(
+        [db_path],
+        metadata={
+            "databases": {"test": {"tables": {"images": {"title": "Some images"}}}},
+            "plugins": {"datasette-render-image-tags": {}},
+        },
     )
+    db = sqlite_utils.Database(db_path)
+    db["images"].upsert(dict(id=1, url=url), pk="id")
+    response = await datasette.client.get("/test/images")
     assert response.status_code == 200
     html = response.text
     if expect_img:
-        expected = '<img src="{}" width="200" loading="lazy">'.format(
-            escape(value.strip())
-        )
+        style = "display: block;margin: 0 auto;max-width: 200px;max-height: 200px;"
+        expected = f'<img src="{url.strip()}" loading="lazy" style="{style}">'
         assert expected in html
     else:
         assert "<img " not in html
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    (
+        ("https://blah/has_url.png"),
+        ("http://blah/has_url.jpg"),
+        ("https://blah/has_url.jpeg"),
+        ("https://blah/has_url.gif"),
+        (" https://blah/has_url.gif "),
+    ),
+)
+async def test_config_changes_size(db_path, url):
+    db = sqlite_utils.Database(db_path)
+    db["images"].upsert(dict(id=1, url=url), pk="id")
+    datasette = Datasette(
+        [db_path],
+        metadata={
+            "databases": {"test": {"tables": {"images": {"title": "Some images"}}}},
+            "plugins": {
+                "datasette-render-image-tags": dict(max_width=400, max_height=300)
+            },
+        },
+    )
+
+    response = await datasette.client.get("/test/images")
+    assert response.status_code == 200
+
+    html = response.text
+    style = "display: block;margin: 0 auto;max-width: 400px;max-height: 300px;"
+    expected = f'<img src="{url.strip()}" loading="lazy" style="{style}">'
+    assert expected in html
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Added support for customizing the img rendering.
In particular you can use a setting "fixed_width" to customize the img width (instead of 200) or use two new settings ("max_width" and "max_height") to make the rendering dynamic.