### PR TITLE
More URI types(including data URIs), show URI as img title

### DIFF
--- a/datasette_render_image_tags/__init__.py
+++ b/datasette_render_image_tags/__init__.py
@@ -1,7 +1,15 @@
 from datasette import hookimpl
 from markupsafe import Markup, escape
 
-ENDS = (".jpg", ".jpeg", ".png", ".gif")
+ENDS = (".jpg", ".jpeg", ".png", ".gif", ".avif", ".webp", ".svg", ".bmp")
+STARTS = (
+    "data:image/jpeg",
+    "data:image/png",
+    "data:image/avif",
+    "data:image/webp",
+    "data:image/svg",
+    "data:image/bmp",
+)
 
 
 @hookimpl
@@ -11,7 +19,22 @@ def render_cell(value):
     value = value.strip()
     if not value or " " in value:
         return
-    if not (value.startswith("http://") or value.startswith("https://")):
+    if not (value.startswith(("http://", "https://", "data:"))):
         return
+    if len(value) < 256:
+        title = value
+    else:
+        title = "Value too long to display"
+
     if any(value.lower().endswith(end) for end in ENDS):
-        return Markup('<img src="{}" width="200" loading="lazy">'.format(escape(value)))
+        return Markup(
+            '<img title="{}" src="{}" width="200" loading="lazy">'.format(
+                escape(title), escape(value)
+            )
+        )
+    if any(value.lower().startswith(start) for start in STARTS):
+        return Markup(
+            '<img title="{}" src="{}" width="200" loading="lazy">'.format(
+                escape(title), escape(value)
+            )
+        )


### PR DESCRIPTION
Adds webp, avif, bmp, and svg support, plus support for data URIs.

If the value is shorter than 256 chars long, uses the value as the title of the image.